### PR TITLE
New multifluid

### DIFF
--- a/reaction_cx.cxx
+++ b/reaction_cx.cxx
@@ -93,7 +93,7 @@ public:
       Ecx[i] += weight * (3. / 2) * (Ti - Tn) * R;
 
       // Fcx is friction between plasma and neutrals
-      Fcx[i] += weight * (Vi - Vn) * R;
+      Fcx[i] += weight * atoms.AA * (Vi - Vn) * R;
 
       if (charge_exchange_escape) {
         // Scx is a redistribution of fast neutrals due to charge exchange

--- a/reaction_ionisation.cxx
+++ b/reaction_ionisation.cxx
@@ -27,11 +27,13 @@ public:
     // Get the species
     // Extract required variables
     Field3D Nn, Tn, Vn;
+    double AA;
     try {
       auto &atoms = *species.at("h");
       Nn = atoms.N;
       Tn = atoms.T;
       Vn = atoms.V;
+      AA = atoms.AA;
     } catch (const std::out_of_range &e) {
       throw BoutException("No 'h' species");
     }
@@ -68,7 +70,7 @@ public:
       Eiz[i] -= weight * (3. / 2) * Tn * R;
 
       // Friction due to ionisation
-      Fiz[i] -= weight * Vn * R;
+      Fiz[i] -= weight * AA * Vn * R;
 
       // Plasma sink due to ionisation (negative)
       Siz[i] -= weight * R;

--- a/reaction_neutral_diffusion.cxx
+++ b/reaction_neutral_diffusion.cxx
@@ -74,7 +74,7 @@ public:
       if (tn < tn_floor / Tnorm) {
         tn = tn_floor / Tnorm;
       }
-      BoutReal vth_n = sqrt(tn); // Normalised to Cs0
+      BoutReal vth_n = sqrt(tn / atoms.AA); // Normalised to Cs0
       
       // Neutral-neutral mean free path
       BoutReal a0 = PI * SQ(5.29e-11);

--- a/reaction_recombination.cxx
+++ b/reaction_recombination.cxx
@@ -23,10 +23,12 @@ public:
     
     // Get the species
     Field3D Ti, Vi;
+    double AA;
     try {
       auto &ions = *species.at("h+");
       Ti = ions.T;
       Vi = ions.V;
+      AA = ions.AA;
     } catch (const std::out_of_range &e) {
       throw BoutException("No 'h+' species");
     }
@@ -66,7 +68,7 @@ public:
       Erec[i] += weight * (3. / 2) * Ti * R;
 
       // Momentum transferred to neutrals
-      Frec[i] += weight * Vi * R;
+      Frec[i] += weight * AA * Vi * R;
 
       // Particles transferred to neutrals
       Srec[i] += weight * R;

--- a/reaction_recycling.cxx
+++ b/reaction_recycling.cxx
@@ -110,7 +110,7 @@ public:
       // Set velocity of neutrals coming from the wall to a fraction of
       // the Franck-Condon energy
       BoutReal Vneut = -vwall * sqrt(3.5 / Tnorm);
-      SNVn(r.ind, mesh->yend, jz) += ntarget * Vneut;
+      SNVn(r.ind, mesh->yend, jz) += atoms.AA * ntarget * Vneut;
       
       // Set temperature of the incoming neutrals to F-C
       SEn(r.ind, mesh->yend, jz) += (3./2) * ntarget * (3.5 / Tnorm);

--- a/reaction_recycling.cxx
+++ b/reaction_recycling.cxx
@@ -51,7 +51,7 @@ public:
 
     if ((*options)["diagnose"].withDefault(false)) {
       // Save additional outputs
-      SAVE_REPEAT(flux_ion);
+      SAVE_REPEAT(flux_ion,flux_neut);
     }
   }
 
@@ -91,7 +91,7 @@ public:
       BoutReal neutral_density = 0.5 * (Nn(r.ind, jy, jz) + Nn(r.ind, jy + 1, jz));
       BoutReal neutral_velocity = 0.5 * (Vn(r.ind, jy, jz) + Vn(r.ind, jy + 1, jz));
       
-      BoutReal flux_neut = neutral_density * neutral_velocity *
+      flux_neut = neutral_density * neutral_velocity *
         (coord->J(r.ind, jy) + coord->J(r.ind, jy + 1)) /
         (sqrt(coord->g_22(r.ind, jy)) + sqrt(coord->g_22(r.ind, jy + 1)));
       
@@ -166,7 +166,7 @@ public:
 private:
   std::string name; // Species name e.g. "h" or "h+"
 
-  BoutReal flux_ion; // Flux of ions to target (output)
+  BoutReal flux_ion,flux_neut; // Flux of ions to target (output)
 
   
   BoutReal frecycle; // Recycling fraction

--- a/sd1d.cxx
+++ b/sd1d.cxx
@@ -38,6 +38,7 @@
 
 #include <bout/constants.hxx>
 #include <bout/physicsmodel.hxx>
+#include <bout/snb.hxx>
 #include <derivs.hxx>
 #include "field_factory.hxx"
 #include <invert_parderiv.hxx>
@@ -48,6 +49,8 @@
 #include "radiation.hxx"
 #include "species.hxx"
 #include "reaction.hxx"
+
+using bout::HeatFluxSNB;
 
 class SD1D : public PhysicsModel {
 protected:
@@ -61,6 +64,15 @@ protected:
     SAVE_ONCE3(Tnorm, Nnorm, Bnorm);      // Save normalisations
 
     OPTION(opt, heat_conduction, true); // Spitzer-Hahm heat conduction
+
+    snb_model = opt["snb_model"]
+                    .doc("Use SNB non-local heat flux model")
+                    .withDefault<bool>(false);	// SNB non-locality
+    if (snb_model) {
+      // Create a solver to calculate the SNB heat flux
+      snb = new HeatFluxSNB();
+    }
+
 
     // Get a list of reactions to include, separated by commas
     
@@ -146,6 +158,10 @@ protected:
 
     if (heat_conduction) {
       SAVE_REPEAT(kappa_epar); // Save coefficient of thermal conduction
+    }
+
+    if (snb_model) {
+      SAVE_REPEAT(Div_Q_SH, Div_Q_SNB);
     }
     
     kappa_epar = 0.0;
@@ -275,7 +291,7 @@ protected:
       ddt(electrons.P) = 0.0;
 
       if (heat_conduction) {
-        
+
         if (update_coefficients) {
           // Update diffusion coefficients
           TRACE("Update coefficients");
@@ -286,10 +302,27 @@ protected:
           kappa_epar.applyBoundary("neumann");
           
         }
-        
-        // NOTE: This factor of 2 is to match SD1D v1, but should be removed
-        // once testing is complete.
-        ddt(electrons.P) += 2. * (2. / 3) * Div_par_diffusion_upwind(kappa_epar, electrons.T);
+
+        if (snb_model) {
+            // SNB non-local heat flux. Also returns the Spitzer-Harm value for comparison
+            // Note: Te in eV, Ne in Nnorm
+            Field2D dy_orig = mesh->getCoordinates()->dy;
+            mesh->getCoordinates()->dy *= rho_s0; // Convert distances to m
+            Div_Q_SNB = snb->divHeatFlux(electrons.T * Tnorm, electrons.N * Nnorm, &Div_Q_SH);
+            mesh->getCoordinates()->dy = dy_orig;
+            
+            // Normalise from eV/m^3/s
+            Div_Q_SNB /= Tnorm * Nnorm * Omega_ci;
+            Div_Q_SH /= Tnorm * Nnorm * Omega_ci;
+
+            // Add to pressure equation
+            ddt(electrons.P) -= 2. * (2. / 3) * Div_Q_SNB;
+          } else {
+            // The standard Spitzer-Harm model
+            // NOTE: Need an extra factor of 2 to match SD1D v1,
+
+            ddt(electrons.P) += 2. * (2. / 3) * Div_par_diffusion_upwind(kappa_epar, electrons.T);
+        }
       }
 
       // Electron pressure acts on ions
@@ -297,7 +330,7 @@ protected:
     }
     
     // Equal electron and ion temperatures
-    ddt(ions.P)   += 0.5*ddt(electrons.P);
+    ddt(ions.P)   += 0.5 * ddt(electrons.P);
     
     return 0;
   }
@@ -384,6 +417,9 @@ private:
   Field3D kappa_epar; // Plasma thermal conduction
   Field3D tau_e;        // Electron collision time
   bool heat_conduction; // Thermal conduction on/off
+  bool snb_model;       // Use the SNB model for heat conduction?
+  HeatFluxSNB *snb;
+  Field3D Div_Q_SH, Div_Q_SNB; // Divergence of heat flux from Spitzer-Harm and SNB
 
   /////////////////////////////////////////////////////////////////
   // Atomic physics transfer channels

--- a/sd1d.cxx
+++ b/sd1d.cxx
@@ -316,12 +316,12 @@ protected:
             Div_Q_SH /= Tnorm * Nnorm * Omega_ci;
 
             // Add to pressure equation
-            ddt(electrons.P) -= 0.5 * (2. / 3) * Div_Q_SNB;
+            ddt(electrons.P) -= (2. / 3) * Div_Q_SNB * ions.ZZ / (1+ions.ZZ);
           } else {
             // The standard Spitzer-Harm model
-            // NOTE: Factor of 0.5 accounts for instant equipartition of energy between electrons and ions in this Te=Ti assumption,
+            // NOTE: Factor of Z/(1+Z) accounts for instant equipartition of energy between electrons and ions in this Te=Ti assumption,
 
-            ddt(electrons.P) += 0.5 * (2. / 3) * Div_par_diffusion_upwind(kappa_epar, electrons.T);
+            ddt(electrons.P) += (2. / 3) * Div_par_diffusion_upwind(kappa_epar, electrons.T) * ions.ZZ / (1+ions.ZZ);
         }
       }
 
@@ -330,7 +330,7 @@ protected:
     }
     
     // Equal electron and ion temperatures
-    ddt(ions.P)   += ddt(electrons.P);
+    ddt(ions.P)   += ddt(electrons.P) / ions.ZZ;
     
     return 0;
   }

--- a/sd1d.cxx
+++ b/sd1d.cxx
@@ -323,14 +323,14 @@ protected:
 
             ddt(electrons.P) += (2. / 3) * Div_par_diffusion_upwind(kappa_epar, electrons.T) * ions.ZZ / (1+ions.ZZ);
         }
-      }
+
+        // Equal electron and ion temperatures
+        ddt(ions.P)   += ddt(electrons.P) / ions.ZZ;
+      }    
 
       // Electron pressure acts on ions
-      ddt(ions.NV) -= Grad_par(electrons.P + ions.P);
+      ddt(ions.NV) -= Grad_par(electrons.P);
     }
-    
-    // Equal electron and ion temperatures
-    ddt(ions.P)   += ddt(electrons.P) / ions.ZZ;
     
     return 0;
   }

--- a/sd1d.cxx
+++ b/sd1d.cxx
@@ -326,7 +326,7 @@ protected:
       }
 
       // Electron pressure acts on ions
-      ddt(ions.NV) -= Grad_par(ions.P);
+      ddt(ions.NV) -= Grad_par(electrons.P + ions.P);
     }
     
     // Equal electron and ion temperatures

--- a/sd1d.cxx
+++ b/sd1d.cxx
@@ -316,12 +316,12 @@ protected:
             Div_Q_SH /= Tnorm * Nnorm * Omega_ci;
 
             // Add to pressure equation
-            ddt(electrons.P) -= 2. * (2. / 3) * Div_Q_SNB;
+            ddt(electrons.P) -= 0.5 * (2. / 3) * Div_Q_SNB;
           } else {
             // The standard Spitzer-Harm model
-            // NOTE: Need an extra factor of 2 to match SD1D v1,
+            // NOTE: Factor of 0.5 accounts for instant equipartition of energy between electrons and ions in this Te=Ti assumption,
 
-            ddt(electrons.P) += 2. * (2. / 3) * Div_par_diffusion_upwind(kappa_epar, electrons.T);
+            ddt(electrons.P) += 0.5 * (2. / 3) * Div_par_diffusion_upwind(kappa_epar, electrons.T);
         }
       }
 
@@ -330,7 +330,7 @@ protected:
     }
     
     // Equal electron and ion temperatures
-    ddt(ions.P)   += 0.5 * ddt(electrons.P);
+    ddt(ions.P)   += ddt(electrons.P);
     
     return 0;
   }

--- a/sd1d.cxx
+++ b/sd1d.cxx
@@ -298,7 +298,7 @@ protected:
           
           tau_e = Omega_ci * tau_e0 * pow(electrons.T, 1.5) / electrons.N;
           
-          kappa_epar = 3.2 * mi_me * 0.5 * electrons.P * tau_e;
+          kappa_epar = 3.2 * mi_me * electrons.P * tau_e;
           kappa_epar.applyBoundary("neumann");
           
         }
@@ -323,13 +323,13 @@ protected:
 
             ddt(electrons.P) += (2. / 3) * Div_par_diffusion_upwind(kappa_epar, electrons.T) * ions.ZZ / (1+ions.ZZ);
         }
-
-        // Equal electron and ion temperatures
-        ddt(ions.P)   += ddt(electrons.P) / ions.ZZ;
       }    
 
       // Electron pressure acts on ions
       ddt(ions.NV) -= Grad_par(electrons.P);
+
+      // Equal electron and ion temperatures
+      ddt(ions.P)   += ddt(electrons.P) / ions.ZZ;
     }
     
     return 0;


### PR DESCRIPTION
Attempting to get new-multifluid simulations to match simulations from the original master branch. Simulations without neutrals matched, both with and without heat conduction, but when neutrals are included the simulations still don't completely match. I think the discrepancy is to do with the boundary conditions for neutrals at the target, and when reactions are on this ends up causing significant differences in the ion density and pressure profiles.

Main changes are:
- Adding the SNB model of heat conduction and the option for a flux-limiter
- Removing factors of 2 from heat conduction in sd1d.cxx that were used before accounting for electron pressure contribution and replaced with the equipartition assumption Z/(1+Z).
- Adding factors of atoms.AA and ions.AA to ddt(NV) in all of the relevant reactions, to account for the new normalisations.
- Changing the definition of the neutral thermal velocity in reaction_neutral_diffusion.cxx to match the new normalisation.