### PR TITLE
Add ability for custom BOUT-dev install at compile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,13 @@ endif()
 message(STATUS "Git revision: ${SD1D_REVISION}")
 
 # BOUT++ is a dependency
-add_subdirectory(external/BOUT-dev)
+option(SD1D_BUILD_BOUT "Build BOUT++ in external/BOUT-dev" ON)
+if(SD1D_BUILD_BOUT)
+  set(BOUT_BUILD_EXAMPLES, OFF) # Don't create example makefiles
+  add_subdirectory(external/BOUT-dev)
+else()
+  find_package(bout++ REQUIRED)
+endif()
 
 set(SD1D_SOURCES
     sd1d.cxx


### PR DESCRIPTION
Use the below flag to compile SD1D with a custom BOUT++ install.
This is useful when you want to compile BOUT++ in a specific way, such as @johnomotani's BOUT-config script (https://github.com/boutproject/BOUT-configs/tree/generic-next) which ensures you have PETSc support.

`-DCMAKE_PREFIX_PATH=<your-path-here>/BOUT-dev/build -DSD1D_BUILD_BOUT=False`  

Adapted from:
https://github.com/bendudson/hermes-3/blob/1491110f16133d0ae97be1082a6acb830e840f6c/CMakeLists.txt#L35-L42