### PR TITLE
Update BOUT++ version

### DIFF
--- a/div_ops.cxx
+++ b/div_ops.cxx
@@ -23,10 +23,10 @@
 #include "div_ops.hxx"
 
 #include <bout/mesh.hxx>
-#include <globals.hxx>
-#include <derivs.hxx>
-#include <output.hxx>
-#include <utils.hxx>
+#include <bout/globals.hxx>
+#include <bout/derivs.hxx>
+#include <bout/output.hxx>
+#include <bout/utils.hxx>
 #include <bout/assert.hxx>
 
 #include <cmath>

--- a/div_ops.hxx
+++ b/div_ops.hxx
@@ -24,7 +24,7 @@
 #ifndef __DIV_OPS_H__
 #define __DIV_OPS_H__
 
-#include <field3d.hxx>
+#include <bout/field3d.hxx>
 
 /*!
  * Parallel diffusion (in y)

--- a/loadmetric.cxx
+++ b/loadmetric.cxx
@@ -18,10 +18,10 @@
     along with SD1D.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <globals.hxx>
-#include <output.hxx>
-#include <utils.hxx>
-#include <field2d.hxx>
+#include <bout/globals.hxx>
+#include <bout/output.hxx>
+#include <bout/utils.hxx>
+#include <bout/field2d.hxx>
 #include <bout/mesh.hxx>
 
 #include "loadmetric.hxx"

--- a/loadmetric.hxx
+++ b/loadmetric.hxx
@@ -21,7 +21,7 @@
 #ifndef __LOADMETRIC_H__
 #define __LOADMETRIC_H__
 
-#include <bout_types.hxx>
+#include <bout/bout_types.hxx>
 
 void LoadMetric(BoutReal Lnorm, BoutReal Bnorm);
 

--- a/radiation.cxx
+++ b/radiation.cxx
@@ -1,8 +1,8 @@
 
-#include <globals.hxx> // for mesh object
-#include <output.hxx>
-#include <boutexception.hxx>
-#include <utils.hxx>
+#include <bout/globals.hxx> // for mesh object
+#include <bout/output.hxx>
+#include <bout/boutexception.hxx>
+#include <bout/utils.hxx>
 
 #include "radiation.hxx"
 

--- a/radiation.hxx
+++ b/radiation.hxx
@@ -3,8 +3,8 @@
 #ifndef __RADIATION_H__
 #define __RADIATION_H__
 
-#include <field3d.hxx>
-#include <bout_types.hxx>
+#include <bout/field3d.hxx>
+#include <bout/bout_types.hxx>
 
 #include <vector>
 #include <cmath>

--- a/sd1d.cxx
+++ b/sd1d.cxx
@@ -40,8 +40,8 @@
 
 #include <bout/constants.hxx>
 #include <bout/physicsmodel.hxx>
-#include <derivs.hxx>
-#include <field_factory.hxx>
+#include <bout/derivs.hxx>
+#include <bout/field_factory.hxx>
 #include <bout/invert_pardiv.hxx>
 #include <bout/snb.hxx>
 #include <bout/fv_ops.hxx>
@@ -1850,7 +1850,7 @@ protected:
                         {"long_name", "neutral atom pressure source"}});
       }
 
-      if (mesh->lastY()) {
+      if (mesh->lastY(0)) {
         set_with_attrs(state["flux_ion"], flux_ion,
                        {{"units", "m^-2 s^-1"},
                         {"conversion", Nnorm * Cs0},


### PR DESCRIPTION
Update to a fork of `master`, https://github.com/boutproject/BOUT-dev/pull/2714

Alternative fix to #24 

- Includes fix to the order of mesh variable outputs, so that metric components are saved after `init()` is called. This fixes the problem where output `J` was not correct
- Changed locations of BOUT++ include files, adding `bout/` prefix.
